### PR TITLE
Fix icon flicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "svelte-hacker-news-pwa",
 			"version": "0.0.1",
 			"dependencies": {
-				"cheerio": "1.0.0-rc.12"
+				"cheerio": "1.0.0-rc.12",
+				"lucide-svelte": "^0.383.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^2.1.1",
@@ -40,7 +41,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -431,7 +431,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
 			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -445,7 +444,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -454,7 +452,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -462,14 +459,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -633,8 +628,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
 		},
 		"node_modules/@types/pug": {
 			"version": "2.0.10",
@@ -646,7 +640,6 @@
 			"version": "8.11.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
 			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -707,7 +700,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -753,7 +745,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
 			"integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -946,7 +937,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
 			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@types/estree": "^1.0.1",
@@ -1030,7 +1020,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"dependencies": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -1092,7 +1081,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1266,7 +1254,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -1557,7 +1544,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
 			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -1622,8 +1608,7 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/lodash.castarray": {
 			"version": "4.4.0",
@@ -1652,11 +1637,18 @@
 				"node": "14 || >=16.14"
 			}
 		},
+		"node_modules/lucide-svelte": {
+			"version": "0.383.0",
+			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.383.0.tgz",
+			"integrity": "sha512-jA4fd9v1gLuE/iNszC7VyIexDnWX06bYpFFTPfBwk0FKh3Paf7FULgotQ8UUY1Lsr6JIMWASh7zKhI2f1bePFw==",
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5.0.0-next.42"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.10",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
 			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
@@ -1664,8 +1656,7 @@
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1934,7 +1925,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -2373,7 +2363,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
 			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2570,7 +2559,6 @@
 			"version": "4.2.17",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
 			"integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"cheerio": "1.0.0-rc.12"
+		"cheerio": "1.0.0-rc.12",
+		"lucide-svelte": "^0.383.0"
 	}
 }

--- a/src/lib/components/icons/YCombinator.svelte
+++ b/src/lib/components/icons/YCombinator.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    let className: string = '';
+    export { className as class }; 
+</script>
+
+<svg
+    class={className}
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 32 32"
+    ><path
+        fill="currentColor"
+        d="M30 2v28H2V2zM16.75 17.969l4.844-9.094H19.55l-2.863 5.688a38.406 38.406 0 0 0-.8 1.675l-.762-1.675L12.3 8.875h-2.188l4.794 8.988v5.906h1.844z"
+    ></path></svg
+>

--- a/src/lib/components/menu/aside/aside-button.svelte
+++ b/src/lib/components/menu/aside/aside-button.svelte
@@ -2,7 +2,6 @@
 	import { activeTab, type Tab } from "$lib/settings";
 
     export let tab: Tab;
-    export let icon: string;
     export let text: string = tab;
 
     function activate(tabName: Tab) {
@@ -17,8 +16,7 @@
     class:active={$activeTab === tab}
     on:click={() => activate(tab)}
 >
-    <slot name="icon" />
-    <iconify-icon {icon} class="text-2xl"></iconify-icon>
+    <slot name="icon"></slot>
     <span class="max-sm:sr-only sm:min-w-[100px] text-left capitalize">{text}</span>
 </button>
 

--- a/src/lib/components/menu/aside/aside.svelte
+++ b/src/lib/components/menu/aside/aside.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-	import type { Tab } from "$lib/settings";
+    import { Info, Settings } from "lucide-svelte";
 	import AsideButton from "./aside-button.svelte";
 
-    let tabs: Array<{ tab: Tab, icon: string}> = [
-        { tab: "settings", icon: "carbon:settings" },
-        { tab: "about", icon: "fluent:info-24-regular" }
-    ]
 </script>
 
 
 <aside class="overflow-auto sm:py-2 min-w-fit bg-zinc-200 dark:bg-zinc-900">
     <ul class="flex flex-col sm:gap-2">
-        {#each tabs as t}
-            <AsideButton {...t} />
-        {/each}
+        <AsideButton tab="settings">
+            <Settings slot="icon" />
+        </AsideButton>
+
+        <AsideButton tab="about">
+            <Info slot="icon" />
+        </AsideButton>
     </ul>
 </aside>

--- a/src/lib/components/menu/menu-main.svelte
+++ b/src/lib/components/menu/menu-main.svelte
@@ -4,6 +4,7 @@
 	import { closeMenu } from "./menu.svelte";
 	import SettingsPane from "./panes/settings/settings-pane.svelte";
 	import AboutPane from "./panes/about-pane.svelte";
+    import { X } from 'lucide-svelte';
 </script>
 
 <div class="flex-1 flex flex-col min-h-0 min-w-0 bg-white dark:bg-zinc-950">
@@ -14,7 +15,7 @@
             on:click={closeMenu}
             class="text-2xl hover:bg-zinc-200 dark:hover:bg-zinc-900 p-2 rounded flex items-center"
         >
-            <iconify-icon icon="ic:round-close"></iconify-icon>
+            <X />
             <span class="sr-only">Close Site Menu</span>
         </button>
     </header>

--- a/src/lib/components/menu/panes/settings/radio-button.svelte
+++ b/src/lib/components/menu/panes/settings/radio-button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { fly } from "svelte/transition";
+	import { CircleCheck } from "lucide-svelte";
+import { fly } from "svelte/transition";
 
     export let group: string | number;
     export let value: string;
@@ -22,12 +23,9 @@
     </div>
     
     {#if selected}
-        <iconify-icon 
-            icon="ph:check-circle" 
-            class="text-2xl" 
-            in:fly={{y: -25}}
-        >
-        </iconify-icon>
+        <span in:fly={{y: -25}}>
+            <CircleCheck />
+        </span>
     {/if}
 
     <input

--- a/src/lib/components/menu/panes/settings/settings-pane.svelte
+++ b/src/lib/components/menu/panes/settings/settings-pane.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { hand, showImagePreviews, theme, highlightLastPost } from "$lib/settings";
+    import { Monitor, MoonStar, Sun } from "lucide-svelte";
 	import RadioButton from "./radio-button.svelte";
 
 </script>
@@ -10,15 +11,15 @@
     
     <div class="flex gap-2 max-sm:flex-col">
         <RadioButton name="theme" value="light" bind:group={$theme}>
-            <iconify-icon icon="ph:sun" class="text-2xl"></iconify-icon>
+            <Sun />
             Light
         </RadioButton>
         <RadioButton name="theme" value="dark" bind:group={$theme}>
-            <iconify-icon icon="tabler:moon-stars" class="text-2xl"></iconify-icon>
+            <MoonStar />
             Dark
         </RadioButton>
         <RadioButton name="theme" value="system" bind:group={$theme}>
-            <iconify-icon icon="ph:monitor" class="text-2xl"></iconify-icon>
+            <Monitor />
             System
         </RadioButton>
     </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from '$app/stores';
+    import { ArrowLeft } from 'lucide-svelte';
 </script>
 
 <div class="p-4 max-w-screen-md mx-auto">
@@ -15,7 +16,7 @@
         href="/" 
         class="flex items-center gap-2 mt-4 px-4 py-4 border border-zinc-300 dark:border-zinc-700 rounded hover:no-underline hover:shadow dark:hover:border-white"
     >
-        <iconify-icon icon="ph:arrow-left-bold" class="text-2xl"></iconify-icon>
+        <ArrowLeft />
         <span>Go Home</span>
     </a>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
 	import Menu, { openMenu } from "$lib/components/menu/menu.svelte";
 	import { onMount } from "svelte";
 	import { clamp, run } from "$lib/util";
+    import { Menu as Burger, ChevronUp } from 'lucide-svelte';
 
     $: selected = $page.url.pathname.split('/')[1] || "top";
 
@@ -35,7 +36,7 @@
             <a href="/jobs" class="relative nav-item" class:selected={selected === "jobs"}>Jobs</a>
         </div>
         <button on:click={openMenu} title="Site Menu" class="ml-auto text-2xl p-2 hover:bg-zinc-200 dark:hover:bg-zinc-900 rounded aspect-square flex items-center">
-            <iconify-icon icon="lucide:menu"></iconify-icon>
+            <Burger />
             <span class="sr-only">Open Site Menu</span>
         </button>
         <Menu />
@@ -60,7 +61,7 @@
         })}
     >
         <span class="sr-only">Scroll to top of page</span>
-        <iconify-icon icon="ion:chevron-up" class="text-2xl"></iconify-icon>
+        <ChevronUp />
     </button>
 {/if}
 

--- a/src/routes/[category=category]/+page.svelte
+++ b/src/routes/[category=category]/+page.svelte
@@ -3,6 +3,7 @@
 	import { hand, showImagePreviews, highlightLastPost } from '$lib/settings.js';
 	import { images } from '$lib/stores.js';
     import { points, type ItemBasic, comments } from '$lib/util.js';
+    import { ArrowLeft, ArrowRight, ArrowUp, ArrowUpRight, MessageSquare } from 'lucide-svelte';
     import { scale } from 'svelte/transition';
 
     export let data;
@@ -121,7 +122,7 @@
                                         class:rounded-br-lg={$hand === "lefty" && ((data.category !== "ask" && data.category !== "jobs") || i === data.items.length - 1)}
                                         class:rounded-tr-lg={$hand === "lefty" && i === 0}
                                     >
-                                        <iconify-icon icon="eva:diagonal-arrow-right-up-fill"></iconify-icon>
+                                        <ArrowUpRight />
                                         <span class="sr-only">Open External Post Link</span>
                                     </a>
                                     {#if data.category !== "ask" && data.category !== "jobs"}
@@ -133,7 +134,7 @@
                                             class:rounded-br-lg={$hand === "lefty" && i === data.items.length - 1}
                                             class:rounded-tr-lg={$hand === "lefty"}
                                         >
-                                            <iconify-icon icon="octicon:comment-24"></iconify-icon>
+                                            <MessageSquare />
                                             <span class="sr-only">Open Post Comments</span>
                                         </a>
                                     {/if}
@@ -170,7 +171,7 @@
                                                 group-hocus:outline-4 group-hocus:outline-zinc-900 
                                                 group-hocus:outline-offset-4 group-hocus:dark:outline-zinc-200"
                                             >
-                                                <iconify-icon icon="eva:diagonal-arrow-right-up-fill"></iconify-icon>
+                                                <ArrowUpRight class="w-[1em] h-[1em]" />
                                                 <span class="sr-only">Open External Post Link</span>
                                             </div>
                                         {/if}
@@ -192,8 +193,11 @@
                                     {/if}
                                     <p class="overflow-hidden text-ellipsis whitespace-nowrap">{item.time_ago}</p>
                                 </div>
-                                <a href="/item/{item.id}" class="px-3 py-1 rounded bg-zinc-200 dark:bg-zinc-900 whitespace-nowrap max-xs:ml-auto lefty:max-xs:ml-0 hover:no-underline">
-                                    <iconify-icon icon="octicon:comment-24" inline></iconify-icon> <span class="leading-none">{item.comments_count}</span> 
+                                <a href="/item/{item.id}" class="px-2 py-1 rounded bg-zinc-200 dark:bg-zinc-900 whitespace-nowrap max-xs:ml-auto lefty:max-xs:ml-0 hover:no-underline">
+                                    <div class="flex gap-1 items-center">
+                                        <MessageSquare class="w-4 h-4" /> 
+                                        <span class="leading-none">{item.comments_count}</span> 
+                                    </div>
                                     <span class="sr-only">Open Post Comments</span>
                                 </a>
                             </div>
@@ -210,7 +214,7 @@
                 href="?p={data.page - 1}" 
                 class="px-4 py-4 border border-zinc-300 dark:border-zinc-700 flex-1 rounded hover:no-underline hover:shadow dark:hover:border-white flex justify-between items-center"
             >
-                <iconify-icon icon="ph:arrow-left-bold" class="text-2xl"></iconify-icon>
+                <ArrowLeft />
                 <span>Previous</span>
             </a>
         {/if}
@@ -221,7 +225,7 @@
                 class:solo-link={data.page <= 1}
             >
                 <span>Next</span>
-                <iconify-icon icon="ph:arrow-right-bold" class="text-2xl"></iconify-icon>
+                <ArrowRight />
             </a>
         {/if}
     </div>

--- a/src/routes/item/[id=int]/+page.svelte
+++ b/src/routes/item/[id=int]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-     function cleanupCodeBlocks(rootNode: HTMLElement) {
+    function cleanupCodeBlocks(rootNode: HTMLElement) {
         let codes = Array.from(rootNode.querySelectorAll("pre > code")) as HTMLDivElement[];
         
         console.log("CODES", codes);
@@ -66,6 +66,7 @@
 	import { fly } from "svelte/transition";
     import { comments, findItemInPage, points } from "$lib/util";
     import { browser } from "$app/environment";
+    import { Share, Share2, ArrowRight, ArrowLeft } from "lucide-svelte";
 
     export let data;
 
@@ -206,15 +207,15 @@
             {/if}
             <div class="flex flex-wrap gap-1 items-center">
                 <button 
-                    class="mr-1 px-2 py-1 bg-zinc-200 dark:bg-zinc-900 rounded"
+                    class="mr-1 px-2 py-1 bg-zinc-200 dark:bg-zinc-900 rounded flex gap-1"
                     on:click={copyLink}
                     on:focusout={() => copied = false}
                 >
                     {#if shareable}
-                        <iconify-icon icon="material-symbols:share" class="w-4" inline></iconify-icon>
+                        <Share2 class="w-4"/>
                         <span>Share</span>
                     {:else}
-                        <iconify-icon icon="material-symbols:share" class="w-4" inline></iconify-icon>
+                        <Share2 class="w-4"/>
                         <span>{copied ? "Copied!" : "Copy Link"}</span>
                     {/if}
                 </button>
@@ -255,7 +256,7 @@
                     href="?p={data.page - 1}#comments" 
                     class="px-4 py-4 border border-zinc-300 dark:border-zinc-700 flex-1 rounded hover:no-underline hover:shadow dark:hover:border-white flex justify-between items-center"
                 >
-                    <iconify-icon icon="ph:arrow-left-bold" class="text-2xl"></iconify-icon>
+                    <ArrowLeft />
                     <span>Previous</span>
                 </a>
             {/if}
@@ -266,7 +267,7 @@
                     class:solo-link={data.page <= 1}
                 >
                     <span>Next</span>
-                    <iconify-icon icon="ph:arrow-right-bold" class="text-2xl"></iconify-icon>
+                    <ArrowRight />
                 </a>
             {/if}
         </div>

--- a/src/routes/item/[id=int]/+page.svelte
+++ b/src/routes/item/[id=int]/+page.svelte
@@ -2,8 +2,6 @@
     function cleanupCodeBlocks(rootNode: HTMLElement) {
         let codes = Array.from(rootNode.querySelectorAll("pre > code")) as HTMLDivElement[];
         
-        console.log("CODES", codes);
-
         let whiteSpaces: number[] = [];
         
         for (let code of codes) {
@@ -67,6 +65,7 @@
     import { comments, findItemInPage, points } from "$lib/util";
     import { browser } from "$app/environment";
     import { Share, Share2, ArrowRight, ArrowLeft } from "lucide-svelte";
+    import YCombinator from "$lib/components/icons/YCombinator.svelte";
 
     export let data;
 
@@ -220,7 +219,7 @@
                     {/if}
                 </button>
                 <a href="https://news.ycombinator.com/item?id={data.item.id}" class="inline-block">
-                    <iconify-icon icon="cib:y-combinator" class="w-4" inline></iconify-icon>
+                    <YCombinator class="inline" />
                     <span>View on Hacker News</span>
                 </a>
             </div>

--- a/src/routes/item/[id=int]/Comment.svelte
+++ b/src/routes/item/[id=int]/Comment.svelte
@@ -5,6 +5,7 @@
     import { comments, type Comment } from "$lib/util";
     import { createEventDispatcher, tick } from "svelte";
     import { cleanupComments } from "./+page.svelte";
+    import { Link, MessageSquare } from "lucide-svelte";
 
     export let index: number;
     export let comment: Comment;
@@ -133,8 +134,7 @@
                         on:click={copyLink}
                         on:focusout={() => copied = false}
                     >
-                        <!-- <iconify-icon icon="fa-solid:link"></iconify-icon> -->
-                        <iconify-icon icon="ph:link-bold" class="w-4" inline></iconify-icon>
+                        <Link class="w-4 h-4" />
                         <div 
                             role="tooltip" 
                             id="copy-{comment.id}" 
@@ -272,8 +272,8 @@
                 on:click={handleShowReplies}
                 class="w-full border-2 border-blue-500 text-blue-500 dark:text-inherit dark:border-white p-2 rounded flex items-center gap-2 hover:no-underline"
             >
-                <iconify-icon icon="octicon:comment-24" class="text-2xl w-6"></iconify-icon>
-                {comment.comments_count} more {comment.comments_count === 1 ? "reply" : "replies"}
+                <MessageSquare />
+                <span>{comment.comments_count} more {comment.comments_count === 1 ? "reply" : "replies"}</span>
             </button>
         </div>
     {/if}

--- a/src/routes/item/[id=int]/Comment.svelte
+++ b/src/routes/item/[id=int]/Comment.svelte
@@ -6,6 +6,7 @@
     import { createEventDispatcher, tick } from "svelte";
     import { cleanupComments } from "./+page.svelte";
     import { Link, MessageSquare } from "lucide-svelte";
+    import YCombinator from "$lib/components/icons/YCombinator.svelte";
 
     export let index: number;
     export let comment: Comment;
@@ -234,7 +235,7 @@
             <div 
                 class="text-zinc-600 dark:text-zinc-400 text-sm flex items-center gap-1 mt-1" 
             >
-                <iconify-icon icon="cib:y-combinator" class="text-base w-4"></iconify-icon>
+                <YCombinator />
                 <a href="https://news.ycombinator.com/reply?id={comment.id}&goto=item?id={item.id}#{comment.id}">Reply</a>
                 <a href="https://news.ycombinator.com/item?id={item.id}#{comment.id}">View</a>
                 <span class="hidden" class:lefty:max-sm:block={!visible}>|</span>


### PR DESCRIPTION
Switch to [lucide](https://lucide.dev/) for the majority of icons because they don't seem to flicker like [iconify](https://iconify.design/). Hopefully I'm right about that. Also still relying on iconify in a few cases where lucide doesn't have an equivalent icon, but these icons are nested behind menus so shouldn't really cause a flicker.